### PR TITLE
FIX: Crashes for models that have change_form_template set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
 python:
-  - "2.7"
+  - "3.6"
   - "3.7"
 env:
-  - DJANGO="Django>=1.8,<1.9"
-  - DJANGO="Django>=1.9,<1.10"
-  - DJANGO="Django>=1.10,<1.11"
-  - DJANGO="Django>=1.11,<2.0"
-  - DJANGO="Django>=2.0,<2.1"
+  # - DJANGO="Django>=1.8,<1.9"
+  # - DJANGO="Django>=1.9,<1.10"
+  # - DJANGO="Django>=1.10,<1.11"
+  # - DJANGO="Django>=1.11,<2.0"
+  # - DJANGO="Django>=2.0,<2.1"
   - DJANGO="Django>=2.1,<2.2"
   - DJANGO="Django>=2.2,<3.0"
   - DJANGO="Django>=3.0,<3.1"
-  - DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  # - DJANGO='https://github.com/django/django/archive/master.tar.gz'
 # command to install dependencies
 install:
   - pip install $DJANGO
@@ -23,22 +23,22 @@ script:
 after_success:
   coveralls
 matrix:
-  allow_failures:
-     - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-  exclude:
-    - python: "3.7"
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: "3.7"
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: "3.7"
-      env: DJANGO="Django>=1.10,<1.11"
-    - python: "2.7"
-      env: DJANGO="Django>=2.0,<2.1"
-    - python: "2.7"
-      env: DJANGO="Django>=2.1,<2.2"
-    - python: "2.7"
-      env: DJANGO="Django>=2.2,<3.0"
-    - python: "2.7"
-      env: DJANGO="Django>=3.0,<3.1"
-    - python: "2.7"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  # allow_failures:
+  #    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  # exclude:
+  #   - python: "3.7"
+  #     env: DJANGO="Django>=1.8,<1.9"
+  #   - python: "3.7"
+  #     env: DJANGO="Django>=1.9,<1.10"
+  #   - python: "3.7"
+  #     env: DJANGO="Django>=1.10,<1.11"
+  #   - python: "2.7"
+  #     env: DJANGO="Django>=2.0,<2.1"
+  #   - python: "2.7"
+  #     env: DJANGO="Django>=2.1,<2.2"
+  #   - python: "2.7"
+  #     env: DJANGO="Django>=2.2,<3.0"
+  #   - python: "2.7"
+  #     env: DJANGO="Django>=3.0,<3.1"
+  #   - python: "2.7"
+  #     env: DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,9 @@ python:
   - "3.6"
   - "3.7"
 env:
-  # - DJANGO="Django>=1.8,<1.9"
-  # - DJANGO="Django>=1.9,<1.10"
-  # - DJANGO="Django>=1.10,<1.11"
-  # - DJANGO="Django>=1.11,<2.0"
-  # - DJANGO="Django>=2.0,<2.1"
   - DJANGO="Django>=2.1,<2.2"
   - DJANGO="Django>=2.2,<3.0"
   - DJANGO="Django>=3.0,<3.1"
-  # - DJANGO='https://github.com/django/django/archive/master.tar.gz'
 # command to install dependencies
 install:
   - pip install $DJANGO
@@ -23,22 +17,5 @@ script:
 after_success:
   coveralls
 matrix:
-  # allow_failures:
-  #    - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-  # exclude:
-  #   - python: "3.7"
-  #     env: DJANGO="Django>=1.8,<1.9"
-  #   - python: "3.7"
-  #     env: DJANGO="Django>=1.9,<1.10"
-  #   - python: "3.7"
-  #     env: DJANGO="Django>=1.10,<1.11"
-  #   - python: "2.7"
-  #     env: DJANGO="Django>=2.0,<2.1"
-  #   - python: "2.7"
-  #     env: DJANGO="Django>=2.1,<2.2"
-  #   - python: "2.7"
-  #     env: DJANGO="Django>=2.2,<3.0"
-  #   - python: "2.7"
-  #     env: DJANGO="Django>=3.0,<3.1"
-  #   - python: "2.7"
-  #     env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  allow_failures:
+     - env: DJANGO="Django>=3.0,<3.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,16 @@
 language: python
 python:
   - "3.6"
-  - "3.7"
+
 env:
-  - DJANGO="Django>=2.1,<2.2"
   - DJANGO="Django>=2.2,<3.0"
-  - DJANGO="Django>=3.0,<3.1"
-# command to install dependencies
+
 install:
   - pip install $DJANGO
   - pip install -q -e .
   - pip install -r requirements.txt
-# command to run tests
+
 script:
   - coverage run --source=massadmin manage.py test --settings=tests.settings
 after_success:
   coveralls
-matrix:
-  allow_failures:
-     - env: DJANGO="Django>=3.0,<3.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Django Mass Edit
 
-[![Build Status](https://app.travis-ci.com/unhaggle/django-mass-edit.svg?branch=master)](https://travis-ci.org/burke-software/django-mass-edit)
+**UH Build Status**
+
+[![UH Build Status](https://app.travis-ci.com/unhaggle/django-mass-edit.svg?branch=master)](https://app.travis-ci.com/github/unhaggle/django-mass-edit)
+
+**Original Author's Build Status**
+
+[![Original Author's Build Status](https://travis-ci.org/burke-software/django-mass-edit.svg?branch=master)](https://travis-ci.org/burke-software/django-mass-edit)
 
 From Stanislaw Adaszewski's [blog](http://algoholic.eu/django-mass-change-admin-site-extension/ ). 
 I've fixed bugs and made changes to make it a production friendly drop-in Django app for bulk changes in Django's 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,5 @@ New maintainers welcome. I (bufke) will only be providing minimal support to kee
 
 ## UH Maintainers
 
-- Fusca Riders
-    - ![Danial Malik](https://github.com/danialmalik)
-    - ![Omar Espana](https://github.com/Chamartin3)
+* [Danial Malik](https://github.com/danialmalik)
+* [Omar Espana](https://github.com/Chamartin3)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Build Status](https://travis-ci.org/burke-software/django-mass-edit.svg?branch=master)](https://travis-ci.org/burke-software/django-mass-edit)
-[![Coverage Status](https://coveralls.io/repos/burke-software/django-mass-edit/badge.svg?branch=master&service=github)](https://coveralls.io/github/burke-software/django-mass-edit?branch=master)
+# Django Mass Edit
+
+[![Build Status](https://app.travis-ci.com/unhaggle/django-mass-edit.svg?branch=master)](https://travis-ci.org/burke-software/django-mass-edit)
 
 From Stanislaw Adaszewski's [blog](http://algoholic.eu/django-mass-change-admin-site-extension/ ). 
 I've fixed bugs and made changes to make it a production friendly drop-in Django app for bulk changes in Django's 
@@ -10,17 +11,17 @@ Image was taken using Grappelli
 
 ![Alt text](https://raw.github.com/burke-software/django-mass-edit/master/doc/screenshot9.png)
 
-# Features
+## Features
 - Drop in app, works with all models in admin
 - Doesn't allow users to edit unique and read only fields
 - Attempts to detect and show users errors
 - Database transactions ensure either all or no objects are changed
 
-# Not implemented
+## Not implemented
 - No support for inlines. Original had this. I commented it out because I felt it was very buggy.
 - Validation errors do not show up by the field they should
 
-# Installation
+## Installation
 
 1. `pip install django-mass-edit`
 2. In `settings.py`, add `massadmin` to `INSTALLED_APPS`
@@ -58,19 +59,19 @@ By default, all models registered in the admin will get `Mass Edit` action.
 
 If you wish to disable this, add this to settings file:
 
-``` python
+```python
 MASSEDIT = {
     'ADD_ACTION_GLOBALLY': False,
 }
 ``` 
 
 Then, to add the mass edit action to specific models, use the provided mixin:
-``` python
+```python
 from massadmin.massadmin import MassEditMixin
 
 class MyModelAdmin(MassEditMixin, admin.ModelAdmin):
     ...
-``` 
+```
 
 ### Session-based URLs
 
@@ -95,7 +96,7 @@ This threshold can be changed in settings:
 MASSEDIT = {
     'SESSION_BASED_URL_THRESHOLD': 10,
 }
-``` 
+```
 
 To always use the session-based URLs, simply put in value `0`.
 
@@ -107,3 +108,9 @@ When you make a pull request - please include a unit test.
 If you want to take on improving the project let me know by opening an issue.
 
 New maintainers welcome. I (bufke) will only be providing minimal support to keep the project running on modern versions of Django. Open an issue if you are interested.
+
+## UH Maintainers
+
+- Fusca Riders
+    - ![Danial Malik](https://github.com/danialmalik)
+    - ![Omar Espana](https://github.com/Chamartin3)

--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -112,6 +112,8 @@ def get_formsets(model, request, obj=None):
 
 class MassAdmin(admin.ModelAdmin):
 
+    mass_change_form_template = None
+
     def __init__(self, model, admin_site):
         try:
             self.admin_obj = admin_site._registry[model]
@@ -188,7 +190,7 @@ class MassAdmin(admin.ModelAdmin):
         request.current_app = self.admin_site.name
         return render(
             request,
-            self.change_form_template or [
+            self.mass_change_form_template or [
                 "admin/%s/%s/mass_change_form.html" %
                 (app_label,
                  opts.object_name.lower()),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.3.1uh
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name = "django-mass-edit",
-    version="3.3.0",
+    version="3.3.1uh",
     author = "David Burke",
     author_email = "david@burkesoftware.com",
     description = ("Make bulk changes in the Django admin interface"),
     license = "BSD",
     keywords = "django admin",
-    url = "https://github.com/burke-software/django-mass-edit",
+    url = "https://github.com/unhaggle/django-mass-edit",
     packages=find_packages(),
     include_package_data=True,
     classifiers=[
@@ -16,7 +16,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
## Description
`change_form_template` is not supported by `MassAdmin` right now. If any model admin has this value set, the app crashes on the mass edit page.

Since the change form and mass edit for serve two different purposes, it makes sense to separate the variable that can be used to override their templates.

### Testing
Testing instructions can be found at https://github.com/unhaggle/tier3/pull/5681