### PR TITLE
MITZ-259 Fix upload for multiple dealerships

### DIFF
--- a/massadmin/massadmin.py
+++ b/massadmin/massadmin.py
@@ -256,6 +256,12 @@ class MassAdmin(admin.ModelAdmin):
                             request.FILES,
                             instance=obj)
 
+                        # refresh InMemoryUploadedFile object.
+                        # It should not cause memory leaks as it
+                        # only fseeks to the beggining of the media file.
+                        for in_memory_file in request.FILES.values():
+                            in_memory_file.open()
+
                         exclude = []
                         for fieldname, field in list(form.fields.items()):
                             if fieldname not in mass_changes_fields:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.3uh
+current_version = 3.3.4uhb2dev0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-mass-edit",
-    version="3.3.3uh",
+    version="3.3.4uhb2dev0",
     author="David Burke",
     author_email="david@burkesoftware.com",
     description=("Make bulk changes in the Django admin interface"),


### PR DESCRIPTION
This PR is created as a result of following ticket investigation: https://motocommerce.atlassian.net/browse/MITZ-259

While testing on local environment it turned out that after single [dealership] instance update pointer reading image file is set to the file end which cause a failure on next instance update. We move the pointer to the begging of the file by [re]opening it. In django in-memory file implementation it just `seeks` to beggining. 

As a side note: this issue is related to local environment only. On production/squash environment where S3 bucket is used we faced a problem with file being closed. It was solved by additional changes in our custom storage implementation (tier3).