### PR TITLE
MI-3229: Using cleaned data

### DIFF
--- a/massadmin/massadmin_improved.py
+++ b/massadmin/massadmin_improved.py
@@ -128,6 +128,8 @@ class MassAdminImproved(massadmin.MassAdmin):
         if not form.is_valid() or not is_valid:
             raise ValidationError(form.errors)
 
+        return form.cleaned_data
+
     def edit_all_values(self, request, queryset, object_ids, ModelForm, mass_changes_fields):
         object_id = object_ids[0]
         formsets = []
@@ -138,7 +140,7 @@ class MassAdminImproved(massadmin.MassAdmin):
 
             data = self.get_mass_change_data(request)
 
-            self.validate_form(request, ModelForm, mass_changes_fields, obj, data)
+            data = self.validate_form(request, ModelForm, mass_changes_fields, obj, data)
 
             # In case of errors Atomic will rollback whole transaction
             with transaction.atomic():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autosync-django-mass-edit",
-    version="3.4.1b5.dev1",
+    version="3.4.1-3",
     author="David Burke",
     author_email="david@burkesoftware.com",
     description=("Make bulk changes in the Django admin interface"),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autosync-django-mass-edit",
-    version="3.4.1-2b5.dev1",
+    version="3.4.1b5.dev1",
     author="David Burke",
     author_email="david@burkesoftware.com",
     description=("Make bulk changes in the Django admin interface"),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="autosync-django-mass-edit",
-    version="3.4.1-2",
+    version="3.4.1-2b5.dev1",
     author="David Burke",
     author_email="david@burkesoftware.com",
     description=("Make bulk changes in the Django admin interface"),


### PR DESCRIPTION
## Description
This ticket fixes usage not-clean data in mass-updates

It achieves it by checking all the changes on a single object, and then applying it to all of the object, using atomic in case of database errors like constrains.

## Testing
1. Go to https://test-dtn--mi-3229-wci01.docker2.motocommerce.ca/uh-adm/
2. Select any model from the list, and enter it's object list page
3. Select at least once object on from the list
4. Select "Bulk Edit Selected" action
5. Press "Go" button next to the drop down
6. After the page loads, select and change at least one of the listed fields (Object in the same line have to me marked and changed to have an effect)
7. Go to the bottom of the page and press "Save"
8. All of the objects selected to change should have edited fields with the value given during point 6, and none of the not selected fields should be changed in any of the objects

## Squash Instance
https://test-dtn--mi-3229-wci01.docker2.motocommerce.ca/uh-adm/

## JIRA
https://motocommerce.atlassian.net/browse/MI-3229

## tier3 branch
https://github.com/unhaggle/tier3/pull/7335